### PR TITLE
More fixes to PU compilation under VS2015

### DIFF
--- a/Plugins/ParticleUniverse/src/ParticleUniverseRoot.cpp
+++ b/Plugins/ParticleUniverse/src/ParticleUniverseRoot.cpp
@@ -24,8 +24,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "ParticleUniversePCH.h"
 #include "ParticleUniverseRoot.h"
 
-template <>
-_ParticleUniverseExport ParticleUniverse::ParticleUniverseRoot*
+template<> 
+ParticleUniverse::ParticleUniverseRoot*
     Ogre::Singleton<ParticleUniverse::ParticleUniverseRoot>::msSingleton = 0;
 
 namespace ParticleUniverse

--- a/Samples/ParticleUniverseDemo/include/ParticleUniverseDemo.h
+++ b/Samples/ParticleUniverseDemo/include/ParticleUniverseDemo.h
@@ -44,6 +44,13 @@ public:
 	{
 	    addInputListener(this);
 		mSceneMgr = getRoot()->createSceneManager("DefaultSceneManager");
+
+		LogManager::getSingleton().getDefaultLog()->logMessage("Registering SceneMgr with RTSS");
+		
+		// register our mSceneMgr with the RTSS (GL3+ requires these lines)
+		Ogre::RTShader::ShaderGenerator* shadergen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+		shadergen->addSceneManager(mSceneMgr);
+
 		mCamera = mSceneMgr->createCamera("Camera");
 		SceneNode* camNode = mSceneMgr->getRootSceneNode()->createChildSceneNode();
 		camNode->attachObject(mCamera);


### PR DESCRIPTION
Your VS2015 fix didn't quite do it yet: it seems the _ParticleUniverseExport directive cause "msSingleton redefinition; different storage class" error under VS2015 also? Removing it I can get the thing to compile and run okay.

We also register demo's SceneManager with RTSS which is required by GL3+.
